### PR TITLE
Add basic unit tests

### DIFF
--- a/tests/guessNumber_test.ts
+++ b/tests/guessNumber_test.ts
@@ -1,0 +1,24 @@
+import { assertEquals } from "./test_deps.ts";
+import { guessNumberGame } from "../games/guessNumber.ts";
+import { GameStatus } from "../types.ts";
+
+Deno.test("guessNumberGame initializes with empty guesses", () => {
+  const state = guessNumberGame.initializeState(50) as any;
+  assertEquals(state, { guesses: [], target: 50 });
+});
+
+Deno.test("guessNumberGame evaluates win when guess matches target", () => {
+  const state = guessNumberGame.initializeState(42) as any;
+  guessNumberGame.updateState(state, "42");
+  const status = guessNumberGame.evaluateStatus(state as any);
+  assertEquals(status, GameStatus.Win);
+});
+
+Deno.test("guessNumberGame evaluates loss after eight guesses", () => {
+  const state = guessNumberGame.initializeState(10) as any;
+  for (let i = 0; i < 8; i++) {
+    guessNumberGame.updateState(state, String(i));
+  }
+  const status = guessNumberGame.evaluateStatus(state as any);
+  assertEquals(status, GameStatus.Loss);
+});

--- a/tests/shuffle_test.ts
+++ b/tests/shuffle_test.ts
@@ -1,0 +1,18 @@
+import { assertEquals, assert } from "./test_deps.ts";
+import { shuffle } from "../utils/shuffle.ts";
+
+Deno.test("shuffle returns same elements", () => {
+  const arr = [1, 2, 3, 4, 5];
+  const shuffled = shuffle([...arr]);
+  assertEquals(shuffled.sort(), arr.sort());
+});
+
+Deno.test("shuffle does not always keep order", () => {
+  const arr = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+  const shuffled = shuffle([...arr]);
+  const again = shuffle([...arr]);
+  assert(
+    arr.join() !== shuffled.join() || arr.join() !== again.join(),
+    "Shuffle did not change order in two attempts",
+  );
+});

--- a/tests/test_deps.ts
+++ b/tests/test_deps.ts
@@ -1,0 +1,9 @@
+export function assert(condition: unknown, message = 'Assertion failed') {
+  if (!condition) throw new Error(message);
+}
+
+export function assertEquals<T>(actual: T, expected: T, message?: string) {
+  if (actual !== expected && JSON.stringify(actual) !== JSON.stringify(expected)) {
+    throw new Error(message ?? `Expected ${JSON.stringify(expected)}, got ${JSON.stringify(actual)}`);
+  }
+}

--- a/tests/wordle_test.ts
+++ b/tests/wordle_test.ts
@@ -1,0 +1,24 @@
+import { assertEquals } from "./test_deps.ts";
+import { initializeWordleState, wordleGame } from "../games/wordle.ts";
+import { GameStatus } from "../types.ts";
+
+Deno.test("initializeWordleState creates empty game state", () => {
+  const state = initializeWordleState("cider");
+  assertEquals(state, { guesses: [], solution: "cider" });
+});
+
+Deno.test("wordleGame evaluates win after correct guess", async () => {
+  const state = initializeWordleState("flame");
+  wordleGame.updateState(state, "flame");
+  const status = await wordleGame.evaluateStatus(state);
+  assertEquals(status, GameStatus.Win);
+});
+
+Deno.test("wordleGame evaluates loss after six wrong guesses", async () => {
+  const state = initializeWordleState("apple");
+  for (let i = 0; i < 6; i++) {
+    wordleGame.updateState(state, "wrong");
+  }
+  const status = await wordleGame.evaluateStatus(state);
+  assertEquals(status, GameStatus.Loss);
+});


### PR DESCRIPTION
## Summary
- add wordle, number-guessing and shuffle tests
- include simple local assertions helper

## Testing
- `deno test --fail-fast`

------
https://chatgpt.com/codex/tasks/task_e_68406ba2878c83259f25626b067e96e8